### PR TITLE
Debug css not applying to online class html

### DIFF
--- a/minecraft-bot-hub/templates/prompt.html
+++ b/minecraft-bot-hub/templates/prompt.html
@@ -783,6 +783,37 @@
             border: 1px solid #fbbf24;
         }
         
+        /* Bot Status Indicator Classes */
+        .bot-status-indicator {
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            min-width: 80px;
+            text-align: center;
+            transition: all 0.2s ease;
+        }
+        
+        .bot-status-indicator.online {
+            background: rgba(34, 197, 94, 0.2);
+            color: #22c55e;
+            border: 1px solid #22c55e;
+        }
+        
+        .bot-status-indicator.offline {
+            background: rgba(239, 68, 68, 0.2);
+            color: #ef4444;
+            border: 1px solid #ef4444;
+        }
+        
+        .bot-status-indicator.connecting {
+            background: rgba(251, 191, 36, 0.2);
+            color: #fbbf24;
+            border: 1px solid #fbbf24;
+        }
+        
         .bot-names-info {
             margin-top: 8px;
             color: #8a8b8c;


### PR DESCRIPTION
Add missing CSS definitions for `.bot-status-indicator` to correctly style bot status indicators.

The JavaScript in `minecraft-bot-hub/templates/prompt.html` was attempting to apply classes like `bot-status-indicator online`, but the corresponding CSS rules were absent, resulting in unstyled bot status displays.

---
<a href="https://cursor.com/background-agent?bcId=bc-80ebe300-577f-47fd-97b3-cf22bec3de4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80ebe300-577f-47fd-97b3-cf22bec3de4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

